### PR TITLE
add a reader/ package for reading puzzlefs images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,4 +14,7 @@ jobs:
             - uses: actions-rs/toolchain@v1
               with:
                 toolchain: stable
+            - name: install dependencies
+              run: |
+                sudo apt-get install libfuse-dev
             - run: make lint check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuse"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e57070510966bfef93662a81cb8aa2b1c7db0964354fa9921434f04b9e8660"
+dependencies = [
+ "libc",
+ "log 0.3.9",
+ "pkg-config",
+ "thread-scoped",
+ "time",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +214,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
 
 [[package]]
+name = "log"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
+dependencies = [
+ "log 0.4.14",
+]
+
+[[package]]
+name = "log"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "nix"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +265,12 @@ name = "os_str_bytes"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "ppv-lite86"
@@ -331,6 +368,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "reader"
+version = "0.1.0"
+dependencies = [
+ "builder",
+ "format",
+ "fuse",
+ "hex",
+ "nix",
+ "oci",
+ "sha2",
+ "tempfile",
+ "thiserror",
+ "time",
 ]
 
 [[package]]
@@ -476,6 +529,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread-scoped"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcbb6aa301e5d3b0b5ef639c9a9c7e2f1c944f177b460c04dc24c69b1fa2bd99"
+
+[[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ members = [
     "exe",
     "format",
     "oci",
+    "reader",
 ]

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -370,8 +370,13 @@ pub fn build_initial_rootfs(rootfs: &Path, oci: &Image) -> Result<Descriptor> {
     oci.put_blob(rootfs_buf.as_slice()).map_err(|e| e.into())
 }
 
+// TODO: figure out how to guard this with #[cfg(test)]
+pub fn build_test_fs(image: &Image) -> Result<Descriptor> {
+    build_initial_rootfs(Path::new("../builder/test"), image)
+}
+
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
 
     use std::convert::TryInto;
@@ -382,15 +387,14 @@ mod tests {
 
     #[test]
     fn test_fs_generation() {
-        let dir = tempdir().unwrap();
-        let image = Image::new(dir.path()).unwrap();
-
         // TODO: verify the hash value here since it's only one thing? problem is as we change the
         // encoding/add stuff to it, the hash will keep changing and we'll have to update the
         // test...
         //
         // but once all that's stabalized, we should verify the metadata hash too.
-        let rootfs_desc = build_initial_rootfs(Path::new("./test"), &image).unwrap();
+        let dir = tempdir().unwrap();
+        let image = Image::new(dir.path()).unwrap();
+        let rootfs_desc = build_test_fs(&image).unwrap();
         let rootfs = Rootfs::new(image.open_raw_blob(&rootfs_desc.digest).unwrap()).unwrap();
 
         // there should be a blob that matches the hash of the test data, since it all gets input

--- a/reader/Cargo.toml
+++ b/reader/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "reader"
+version = "0.1.0"
+authors = ["Tycho Andersen <tycho@tycho.pizza>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+format = { path = "../format" }
+oci = { path = "../oci" }
+fuse = "*"
+thiserror = "*"
+time = "*"
+nix = "*"
+
+[dev-dependencies]
+builder = { path = "../builder" }
+tempfile = "*"
+sha2 = "*"
+hex = "*"

--- a/reader/src/error.rs
+++ b/reader/src/error.rs
@@ -1,0 +1,31 @@
+use std::io;
+use std::os::raw::c_int;
+
+use nix::errno::Errno;
+use thiserror::Error;
+
+use format::WireFormatError;
+
+#[derive(Error, Debug)]
+pub enum FSError {
+    #[error("fs error")]
+    IO(#[from] io::Error),
+
+    #[error("error unpacking metadata")]
+    WireFormat(#[from] WireFormatError),
+}
+
+impl FSError {
+    pub fn to_errno(&self) -> c_int {
+        match self {
+            FSError::IO(ioe) => ioe.raw_os_error().unwrap_or(Errno::EINVAL as i32) as c_int,
+            FSError::WireFormat(wfe) => wfe.to_errno(),
+        }
+    }
+
+    pub fn from_errno(errno: Errno) -> FSError {
+        FSError::IO(io::Error::from_raw_os_error(errno as i32))
+    }
+}
+
+pub type FSResult<T> = std::result::Result<T, FSError>;

--- a/reader/src/fuse.rs
+++ b/reader/src/fuse.rs
@@ -1,0 +1,496 @@
+extern crate time;
+
+use std::convert::TryInto;
+use std::ffi::{OsStr, OsString};
+use std::os::raw::c_int;
+use std::path::Path;
+
+use fuse::{FileAttr, FileType, Filesystem, ReplyData, ReplyEntry, ReplyOpen, Request};
+use nix::errno::Errno;
+use nix::fcntl::OFlag;
+use time::Timespec;
+
+use super::error::{FSError, FSResult};
+use super::puzzlefs::{Inode, InodeMode, PuzzleFS};
+
+pub struct Fuse<'a> {
+    pfs: &'a mut PuzzleFS<'a>,
+    // TODO: LRU cache inodes or something. I had problems fiddling with the borrow checker for the
+    // cache, so for now we just do each lookup every time.
+}
+
+fn mode_to_fuse_type(inode: &Inode) -> FSResult<FileType> {
+    Ok(match inode.mode {
+        InodeMode::File { .. } => FileType::RegularFile,
+        InodeMode::Dir { .. } => FileType::Directory,
+        InodeMode::Other => match inode.inode.mode {
+            format::InodeMode::Fifo => FileType::NamedPipe,
+            format::InodeMode::Chr { .. } => FileType::CharDevice,
+            format::InodeMode::Blk { .. } => FileType::BlockDevice,
+            format::InodeMode::Lnk => FileType::Symlink,
+            format::InodeMode::Sock => FileType::Socket,
+            _ => return Err(FSError::from_errno(Errno::EINVAL)),
+        },
+    })
+}
+
+impl<'a> Fuse<'a> {
+    pub fn new(pfs: &'a mut PuzzleFS<'a>) -> Fuse<'a> {
+        Fuse { pfs }
+    }
+
+    fn _lookup(&mut self, parent: u64, name: &OsStr) -> FSResult<FileAttr> {
+        let dir = self.pfs.find_inode(parent)?;
+        let ino = dir.dir_lookup(name)?;
+        self._getattr(ino)
+    }
+
+    fn _getattr(&mut self, ino: u64) -> FSResult<FileAttr> {
+        let ic = self.pfs.find_inode(ino)?;
+        let kind = mode_to_fuse_type(&ic)?;
+        let len = ic.file_len().unwrap_or(0);
+        Ok(FileAttr {
+            ino: ic.inode.ino,
+            size: len,
+            blocks: 0,
+            atime: time::Timespec::new(0, 0),
+            mtime: time::Timespec::new(0, 0),
+            ctime: time::Timespec::new(0, 0),
+            crtime: time::Timespec::new(0, 0),
+            kind,
+            perm: 0o644,
+            nlink: 0,
+            uid: ic.inode.uid,
+            gid: ic.inode.gid,
+            rdev: 0,
+            flags: 0,
+        })
+    }
+
+    fn _open(&self, flags_i: u32, reply: ReplyOpen) {
+        let allowed_flags =
+            OFlag::O_RDONLY | OFlag::O_PATH | OFlag::O_NONBLOCK | OFlag::O_DIRECTORY;
+        let flags = OFlag::from_bits_truncate(flags_i.try_into().unwrap());
+        if !allowed_flags.contains(flags) {
+            reply.error(Errno::EROFS as i32)
+        } else {
+            // stateless open for now, slower maybe
+            reply.opened(0, flags_i);
+        }
+    }
+
+    fn _read(&mut self, ino: u64, offset: u64, size: u32) -> FSResult<Vec<u8>> {
+        let inode = self.pfs.find_inode(ino)?;
+        self.pfs.file_read(&inode, offset, size)
+    }
+
+    fn _readdir(
+        &mut self,
+        ino: u64,
+        offset: i64,
+        reply: &mut fuse::ReplyDirectory,
+    ) -> FSResult<()> {
+        let dir = self.pfs.find_inode(ino)?;
+        let mut entries = dir
+            .dir_entries()?
+            .iter()
+            .collect::<Vec<(&OsString, &format::Ino)>>();
+        entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+        for (index, (name, ino_r)) in entries.into_iter().enumerate().skip(offset as usize) {
+            let ino = *ino_r;
+            let inode = self.pfs.find_inode(ino)?;
+            let kind = mode_to_fuse_type(&inode)?;
+
+            // if the buffer is full, let's skip the extra lookups
+            if reply.add(ino, (index + 1) as i64, kind, name) {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Filesystem for Fuse<'_> {
+    fn init(&mut self, _req: &Request) -> Result<(), c_int> {
+        Ok(())
+    }
+
+    fn destroy(&mut self, _req: &Request) {}
+    fn forget(&mut self, _req: &Request, _ino: u64, _nlookup: u64) {}
+
+    // puzzlefs is readonly, so we can ignore a bunch of requests
+    fn setattr(
+        &mut self,
+        _req: &Request,
+        _ino: u64,
+        _mode: Option<u32>,
+        _uid: Option<u32>,
+        _gid: Option<u32>,
+        _size: Option<u64>,
+        _atime: Option<Timespec>,
+        _mtime: Option<Timespec>,
+        _fh: Option<u64>,
+        _crtime: Option<Timespec>,
+        _chgtime: Option<Timespec>,
+        _bkuptime: Option<Timespec>,
+        _flags: Option<u32>,
+        reply: fuse::ReplyAttr,
+    ) {
+        reply.error(Errno::EROFS as i32)
+    }
+
+    fn mknod(
+        &mut self,
+        _req: &Request,
+        _parent: u64,
+        _name: &OsStr,
+        _mode: u32,
+        _rdev: u32,
+        reply: ReplyEntry,
+    ) {
+        reply.error(Errno::EROFS as i32)
+    }
+
+    fn mkdir(
+        &mut self,
+        _req: &Request,
+        _parent: u64,
+        _name: &OsStr,
+        _mode: u32,
+        reply: ReplyEntry,
+    ) {
+        reply.error(Errno::EROFS as i32)
+    }
+
+    fn unlink(&mut self, _req: &Request, _parent: u64, _name: &OsStr, reply: fuse::ReplyEmpty) {
+        reply.error(Errno::EROFS as i32)
+    }
+
+    fn rmdir(&mut self, _req: &Request, _parent: u64, _name: &OsStr, reply: fuse::ReplyEmpty) {
+        reply.error(Errno::EROFS as i32)
+    }
+
+    fn symlink(
+        &mut self,
+        _req: &Request,
+        _parent: u64,
+        _name: &OsStr,
+        _link: &Path,
+        reply: ReplyEntry,
+    ) {
+        reply.error(Errno::EROFS as i32)
+    }
+
+    fn rename(
+        &mut self,
+        _req: &Request,
+        _parent: u64,
+        _name: &OsStr,
+        _newparent: u64,
+        _newname: &OsStr,
+        reply: fuse::ReplyEmpty,
+    ) {
+        reply.error(Errno::EROFS as i32)
+    }
+
+    fn link(
+        &mut self,
+        _req: &Request,
+        _ino: u64,
+        _newparent: u64,
+        _newname: &OsStr,
+        reply: ReplyEntry,
+    ) {
+        reply.error(Errno::EROFS as i32)
+    }
+
+    fn write(
+        &mut self,
+        _req: &Request,
+        _ino: u64,
+        _fh: u64,
+        _offset: i64,
+        _data: &[u8],
+        _flags: u32,
+        reply: fuse::ReplyWrite,
+    ) {
+        reply.error(Errno::EROFS as i32)
+    }
+
+    fn flush(
+        &mut self,
+        _req: &Request,
+        _ino: u64,
+        _fh: u64,
+        _lock_owner: u64,
+        reply: fuse::ReplyEmpty,
+    ) {
+        reply.error(Errno::EROFS as i32)
+    }
+
+    fn fsync(
+        &mut self,
+        _req: &Request,
+        _ino: u64,
+        _fh: u64,
+        _datasync: bool,
+        reply: fuse::ReplyEmpty,
+    ) {
+        reply.error(Errno::EROFS as i32)
+    }
+
+    fn fsyncdir(
+        &mut self,
+        _req: &Request,
+        _ino: u64,
+        _fh: u64,
+        _datasync: bool,
+        reply: fuse::ReplyEmpty,
+    ) {
+        reply.error(Errno::EROFS as i32)
+    }
+
+    fn setxattr(
+        &mut self,
+        _req: &Request,
+        _ino: u64,
+        _name: &OsStr,
+        _value: &[u8],
+        _flags: u32,
+        _position: u32,
+        reply: fuse::ReplyEmpty,
+    ) {
+        reply.error(Errno::EROFS as i32)
+    }
+
+    fn removexattr(&mut self, _req: &Request, _ino: u64, _name: &OsStr, reply: fuse::ReplyEmpty) {
+        reply.error(Errno::EROFS as i32)
+    }
+
+    fn create(
+        &mut self,
+        _req: &Request,
+        _parent: u64,
+        _name: &OsStr,
+        _mode: u32,
+        _flags: u32,
+        reply: fuse::ReplyCreate,
+    ) {
+        reply.error(Errno::EROFS as i32)
+    }
+
+    fn getlk(
+        &mut self,
+        _req: &Request,
+        _ino: u64,
+        _fh: u64,
+        _lock_owner: u64,
+        _start: u64,
+        _end: u64,
+        _typ: u32,
+        _pid: u32,
+        reply: fuse::ReplyLock,
+    ) {
+        reply.error(Errno::EROFS as i32)
+    }
+
+    fn setlk(
+        &mut self,
+        _req: &Request,
+        _ino: u64,
+        _fh: u64,
+        _lock_owner: u64,
+        _start: u64,
+        _end: u64,
+        _typ: u32,
+        _pid: u32,
+        _sleep: bool,
+        reply: fuse::ReplyEmpty,
+    ) {
+        reply.error(Errno::EROFS as i32)
+    }
+
+    fn lookup(&mut self, _req: &Request, parent: u64, name: &OsStr, reply: ReplyEntry) {
+        match self._lookup(parent, name) {
+            Ok(attr) => {
+                // http://libfuse.github.io/doxygen/structfuse__entry__param.html
+                let ttl = Timespec::new(std::i64::MAX, 0);
+                let generation = 0;
+                reply.entry(&ttl, &attr, generation)
+            }
+            Err(e) => reply.error(e.to_errno()),
+        }
+    }
+
+    fn getattr(&mut self, _req: &Request, ino: u64, reply: fuse::ReplyAttr) {
+        match self._getattr(ino) {
+            Ok(attr) => {
+                // http://libfuse.github.io/doxygen/structfuse__entry__param.html
+                let ttl = Timespec::new(std::i64::MAX, 0);
+                reply.attr(&ttl, &attr)
+            }
+            Err(e) => reply.error(e.to_errno()),
+        }
+    }
+
+    fn readlink(&mut self, _req: &Request, _ino: u64, reply: ReplyData) {
+        reply.error(Errno::EISNAM as i32)
+    }
+
+    fn open(&mut self, _req: &Request, _ino: u64, flags: u32, reply: ReplyOpen) {
+        self._open(flags, reply)
+    }
+
+    fn read(
+        &mut self,
+        _req: &Request,
+        ino: u64,
+        _fh: u64,
+        offset: i64,
+        size: u32,
+        reply: ReplyData,
+    ) {
+        // TODO: why i64 from the fuse API here?
+        let uoffset: u64 = offset.try_into().unwrap();
+        match self._read(ino, uoffset, size) {
+            Ok(data) => reply.data(data.as_slice()),
+            Err(e) => reply.error(e.to_errno()),
+        }
+    }
+
+    fn release(
+        &mut self,
+        _req: &Request,
+        _ino: u64,
+        _fh: u64,
+        _flags: u32,
+        _lock_owner: u64,
+        _flush: bool,
+        reply: fuse::ReplyEmpty,
+    ) {
+        // TODO: purge from our cache here? dcache should save us too...
+        reply.ok()
+    }
+
+    fn opendir(&mut self, _req: &Request, _ino: u64, flags: u32, reply: ReplyOpen) {
+        self._open(flags, reply)
+    }
+
+    fn readdir(
+        &mut self,
+        _req: &Request,
+        ino: u64,
+        _fh: u64,
+        offset: i64,
+        mut reply: fuse::ReplyDirectory,
+    ) {
+        match self._readdir(ino, offset, &mut reply) {
+            Ok(_) => reply.ok(),
+            Err(e) => reply.error(e.to_errno()),
+        }
+    }
+
+    fn releasedir(
+        &mut self,
+        _req: &Request,
+        _ino: u64,
+        _fh: u64,
+        _flags: u32,
+        reply: fuse::ReplyEmpty,
+    ) {
+        // TODO: again maybe purge from cache?
+        reply.ok()
+    }
+
+    fn statfs(&mut self, _req: &Request, _ino: u64, reply: fuse::ReplyStatfs) {
+        reply.statfs(
+            0,   // blocks
+            0,   // bfree
+            0,   // bavail
+            0,   // files
+            0,   // ffree
+            0,   // bsize
+            256, // namelen
+            0,   // frsize
+        )
+    }
+
+    fn getxattr(
+        &mut self,
+        _req: &Request,
+        _ino: u64,
+        _name: &OsStr,
+        _size: u32,
+        reply: fuse::ReplyXattr,
+    ) {
+        // TODO: encoding for xattrs
+        reply.error(Errno::ENOMEDIUM as i32)
+    }
+
+    fn listxattr(&mut self, _req: &Request, _ino: u64, _size: u32, reply: fuse::ReplyXattr) {
+        reply.error(Errno::EDQUOT as i32)
+    }
+
+    fn access(&mut self, _req: &Request, _ino: u64, _mask: u32, reply: fuse::ReplyEmpty) {
+        reply.ok()
+    }
+
+    fn bmap(
+        &mut self,
+        _req: &Request,
+        _ino: u64,
+        _blocksize: u32,
+        _idx: u64,
+        reply: fuse::ReplyBmap,
+    ) {
+        reply.error(Errno::ENOLCK as i32)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::io;
+    use std::path::Path;
+
+    use super::*;
+
+    extern crate hex;
+    use sha2::{Digest, Sha256};
+    use tempfile::tempdir;
+
+    use builder::build_test_fs;
+    use oci::Image;
+
+    #[test]
+    fn test_fuse() {
+        let dir = tempdir().unwrap();
+        let image = Image::new(dir.path()).unwrap();
+        let rootfs_desc = build_test_fs(&image).unwrap();
+        let mut pfs = PuzzleFS::new(&image, &rootfs_desc.digest).unwrap();
+        let fuse = Fuse::new(&mut pfs);
+        let mountpoint = tempdir().unwrap();
+        let session = fuse::Session::new(fuse, Path::new(mountpoint.path()), &[]).unwrap();
+        let _bg = unsafe { fuse::BackgroundSession::new(session) };
+
+        let ents = fs::read_dir(mountpoint.path())
+            .unwrap()
+            .collect::<io::Result<Vec<fs::DirEntry>>>()
+            .unwrap();
+        assert_eq!(ents.len(), 1);
+        assert_eq!(
+            ents[0].path().strip_prefix(mountpoint.path()).unwrap(),
+            Path::new("SekienAkashita.jpg")
+        );
+
+        let mut hasher = Sha256::new();
+        let mut f = fs::File::open(ents[0].path()).unwrap();
+        io::copy(&mut f, &mut hasher).unwrap();
+        let digest = hasher.finalize();
+        const FILE_DIGEST: &str =
+            "d9e749d9367fc908876749d6502eb212fee88c9a94892fb07da5ef3ba8bc39ed";
+        assert_eq!(hex::encode(digest), FILE_DIGEST);
+    }
+}

--- a/reader/src/lib.rs
+++ b/reader/src/lib.rs
@@ -1,0 +1,4 @@
+mod error;
+mod fuse;
+mod puzzlefs;
+pub use crate::fuse::Fuse;

--- a/reader/src/puzzlefs.rs
+++ b/reader/src/puzzlefs.rs
@@ -1,0 +1,148 @@
+use std::cmp::min;
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::ffi::{OsStr, OsString};
+
+use nix::errno::Errno;
+
+use format::{FileChunk, Ino, MetadataBlob};
+use oci::Image;
+
+use super::error::{FSError, FSResult};
+
+pub struct Inode {
+    pub inode: format::Inode,
+    pub mode: InodeMode,
+}
+
+impl Inode {
+    fn new(layer: &mut MetadataBlob, inode: format::Inode) -> FSResult<Inode> {
+        let mode = match inode.mode {
+            format::InodeMode::Reg { offset } => {
+                let chunks = layer.read_file_chunks(offset)?;
+                InodeMode::File { chunks }
+            }
+            format::InodeMode::Dir { offset } => {
+                let mut dir_ents = layer.read_dir_list(offset)?;
+                let entries = dir_ents
+                    .entries
+                    .drain(..)
+                    .map(|de| (de.name, de.ino))
+                    .collect();
+                InodeMode::Dir { entries }
+            }
+            _ => InodeMode::Other,
+        };
+
+        Ok(Inode { inode, mode })
+    }
+
+    pub fn dir_entries(&self) -> FSResult<&HashMap<OsString, Ino>> {
+        match &self.mode {
+            InodeMode::Dir { entries } => Ok(entries),
+            _ => Err(FSError::from_errno(Errno::ENOTDIR)),
+        }
+    }
+
+    pub fn dir_lookup(&self, name: &OsStr) -> FSResult<u64> {
+        let entries = self.dir_entries()?;
+        entries
+            .get(name)
+            .cloned()
+            .ok_or_else(|| FSError::from_errno(Errno::ENOENT))
+    }
+
+    pub fn file_len(&self) -> FSResult<u64> {
+        let chunks = match &self.mode {
+            InodeMode::File { chunks } => chunks,
+            _ => return Err(FSError::from_errno(Errno::ENOTDIR)),
+        };
+        Ok(chunks.iter().map(|c| c.len).sum())
+    }
+}
+
+pub enum InodeMode {
+    File { chunks: Vec<FileChunk> },
+    Dir { entries: HashMap<OsString, Ino> },
+    Other,
+}
+
+pub struct PuzzleFS<'a> {
+    oci: &'a Image<'a>,
+    layers: Vec<format::MetadataBlob>,
+}
+
+impl<'a> PuzzleFS<'a> {
+    pub fn new(oci: &'a Image, digest: &[u8; 32]) -> FSResult<PuzzleFS<'a>> {
+        let rootfs = format::Rootfs::new(oci.open_raw_blob(digest)?)?;
+        let layers = rootfs
+            .metadatas
+            .iter()
+            .map(|md| -> FSResult<MetadataBlob> {
+                let digest = &<[u8; 32]>::try_from(md)?;
+                oci.open_metadata_blob(digest).map_err(|e| e.into())
+            })
+            .collect::<FSResult<Vec<MetadataBlob>>>()?;
+        Ok(PuzzleFS { layers, oci })
+    }
+
+    pub fn find_inode(&mut self, ino: u64) -> FSResult<Inode> {
+        for mut layer in self.layers.iter_mut() {
+            if let Some(inode) = layer.find_inode(ino)? {
+                return Inode::new(&mut layer, inode);
+            }
+        }
+
+        Err(FSError::from_errno(Errno::ENOENT))
+    }
+
+    pub fn file_read(&self, inode: &Inode, offset: u64, size: u32) -> FSResult<Vec<u8>> {
+        let chunks = match &inode.mode {
+            InodeMode::File { chunks } => chunks,
+            _ => return Err(FSError::from_errno(Errno::ENOTDIR)),
+        };
+
+        // TODO: fix all this casting...
+        let end = offset + u64::from(size);
+        let mut data = vec![0_u8; size as usize];
+
+        let mut file_offset = 0;
+        let mut buf_offset = 0;
+        for chunk in chunks {
+            // have we read enough?
+            if file_offset > end {
+                break;
+            }
+
+            // should we skip this chunk?
+            if file_offset + chunk.len < offset {
+                file_offset += chunk.len;
+                continue;
+            }
+
+            // ok, need to read this chunk; how much?
+            let left_in_buf = u64::from(size) - buf_offset;
+            let to_read: usize = min(left_in_buf, chunk.len) as usize;
+
+            let start = buf_offset as usize;
+            let finish = start + to_read;
+            let addl_offset = if offset > file_offset {
+                offset - file_offset
+            } else {
+                0
+            };
+            file_offset += addl_offset;
+
+            // how many did we actually read?
+            let n = self
+                .oci
+                .fill_from_chunk(chunk.blob, addl_offset, &mut data[start..finish])?;
+            file_offset += n as u64;
+            buf_offset += n as u64;
+        }
+
+        // discard any extra if we hit EOF
+        data.truncate(buf_offset as usize);
+        Ok(data)
+    }
+}


### PR DESCRIPTION
This package consists of two layers:

1. a "puzzlefs" module, which does the reading of the wire format and
   piecing it together (e.g. turning a local offset reference to a
   directory into an actual directory listing, or reading a file from file
   chunks, neither of which are are appropriate for the wire format).

2. a "fuse" module, which does the fuse bits (mostly responding with -EROFS
   or simple file/dir listing responses for now)

There are a couple of rust uglinesses in this code: the first is all of the
casts back and forth between usize and u64 in file_read(). This won't
matter for x86_64 since they're the same size, but for other platforms it
might fail. It's also just ugly. I spent a while trying to figure out a
nicer way to do this and eventually gave up :)

The second is exporting test code from the builder package to the reader
package: we'd like to build filesystems with known contents to test with,
but not expose a function to do this as a public API since it won't make
sense for other people. However, it doesn't seem to be possible to only
expose functions in test mode across packages, so we might have to
experiment with rust features or something to accomplish this. For now, we
just export the function as part of the public API. Also, the fuse bits
could be better tested with different chunking parameters so that it ends
up reading things from different chunks sort of like fastcdc_fs.rs does; it
would be nice to export that stuff to tests somehow as well.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>