### PR TITLE
oci: verify putting the same blob twice works

### DIFF
--- a/oci/src/lib.rs
+++ b/oci/src/lib.rs
@@ -189,4 +189,17 @@ mod tests {
         let index2 = image2.get_index().unwrap();
         assert_eq!(index.manifests, index2.manifests);
     }
+
+    #[test]
+    fn double_put_ok() {
+        let dir = tempdir().unwrap();
+        let image = Image::new(dir.path()).unwrap();
+        let desc1 = image
+            .put_blob::<_, compression::Noop, media_types::Chunk>("meshuggah rocks".as_bytes())
+            .unwrap();
+        let desc2 = image
+            .put_blob::<_, compression::Noop, media_types::Chunk>("meshuggah rocks".as_bytes())
+            .unwrap();
+        assert_eq!(desc1, desc2);
+    }
 }


### PR DESCRIPTION
This works because tempfile::NamedTempFile::persist() deletes the file it's
about to persist to. Maybe we should stat() before we delete, but it's
always going to be a TOCTOU and we don't lock anyways...

We'll rely on this to work in the future when generating delta layers on
top of an existing image+tag.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>