### PR TITLE
builder: add some experiments about FCDC stabilization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,7 @@ version = "0.1.0"
 dependencies = [
  "compression",
  "fastcdc",
+ "fastrand",
  "format",
  "oci",
  "serde",
@@ -252,6 +253,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5afa29be46b12c8c380b997def8d1ac77c2665da93eb0a768fab0bf4db79333f"
 
 [[package]]
+name = "fastrand"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77b705829d1e87f762c2df6da140b26af5839e1033aa84aa5f56bb688e4e1bdb"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +382,15 @@ checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -15,3 +15,4 @@ fastcdc = "*"
 [dev-dependencies]
 tempfile = "*"
 serde = "*"
+fastrand = "*"


### PR DESCRIPTION
Not that we need to be running this code on every commit, but it is useful
to have around and it's not very expensive to run.

At least it is an experimental demonstration of the fact that fastcdc can
stabilize fairly quickly. There's probably some theoretical guarantees one
could derive, but I'm bad at math.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>