### PR TITLE
puzzlefs,format: add primitive for resolving "max" inode

### DIFF
--- a/format/src/types.rs
+++ b/format/src/types.rs
@@ -645,6 +645,11 @@ impl MetadataBlob {
     }
 
     pub fn read_inodes(&mut self) -> Result<Vec<Inode>> {
+        self.f.seek(io::SeekFrom::Start(0))?;
         read_one(&mut self.f)
+    }
+
+    pub fn max_ino(&mut self) -> Result<Option<Ino>> {
+        Ok(self.read_inodes()?.last().map(|inode| inode.ino))
     }
 }

--- a/reader/src/puzzlefs.rs
+++ b/reader/src/puzzlefs.rs
@@ -168,6 +168,17 @@ impl<'a> PuzzleFS<'a> {
 
         Err(format::WireFormatError::from_errno(Errno::ENOENT))
     }
+
+    pub fn max_inode(&mut self) -> Result<Ino> {
+        let mut max: Ino = 1;
+        for layer in self.layers.iter_mut() {
+            if let Some(ino) = layer.max_ino()? {
+                max = std::cmp::max(ino, max)
+            }
+        }
+
+        Ok(max)
+    }
 }
 
 pub struct FileReader<'a> {
@@ -232,5 +243,6 @@ mod tests {
             hex::encode(digest),
             "d9e749d9367fc908876749d6502eb212fee88c9a94892fb07da5ef3ba8bc39ed"
         );
+        assert_eq!(pfs.max_inode().unwrap(), 2);
     }
 }


### PR DESCRIPTION
we'll need this for generating FS deltas, since we don't want to re-use
inodes. this means that inode numbers are monotonically increasing and will
never be re-used. however, this seems like it's maybe OK, since the
filesystem is read-only, and inodes will only ever be orphaned if a file is
deleted in a higher layer.

if this becomes a problem, we can probably do orphan resolution where we do
some fancy math to figure out which inodes we can re-use. but let's just
punt for now :)

We also fix a bug where we didn't seek when parsing inodes :). this wasn't
manifested in the current code, but was kind of a foot-gun API.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>