### PR TITLE
Use a specific nightly toolchain as a workaround for building puzzlefs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
             - uses: actions/checkout@v2
             - uses: actions-rs/toolchain@v1
               with:
-                toolchain: nightly
+                toolchain: nightly-2022-08-02
                 components: clippy, rustfmt
             - name: install dependencies
               run: |

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
 SRC=$(shell find . -name \*.rs | grep -v "^./target")
 
 target/debug/puzzlefs: $(SRC)
-	cargo +nightly build
+	cargo build
 
 .PHONY: check
 check:
-	RUST_BACKTRACE=1 cargo +nightly test -- --nocapture
+	RUST_BACKTRACE=1 cargo test -- --nocapture
 
 .PHONY: lint
 lint: $(SRC)
 	rustfmt --check $(SRC)
-	cargo +nightly clippy --all-targets --all-features -- -D warnings -A clippy::upper-case-acronyms
+	cargo clippy --all-targets --all-features -- -D warnings -A clippy::upper-case-acronyms
 
 .PHONY: fmt
 fmt:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel="nightly-2022-08-02"


### PR DESCRIPTION
Starting from nightly-2022-08-03, puzzlefs no longer builds because of the following error:
error[E0407]: method `backtrace` is not a member of trait `std::error::Error`
  --> format/src/error.rs:13:10
   |
13 | #[derive(Error)]
   |          ^^^^^ not a member of trait `std::error::Error`
   |
   = note: this error originates in the derive macro `Error` (in Nightly builds, run with -Z macro-backtrace for more info)

Use nightly-2022-08-02 for now for lack of a better solution.

Signed-off-by: Ariel Miculas <amiculas@cisco.com>