### PR TITLE
Replace fuse with fuser, a maintained fork of fuse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,7 +288,7 @@ checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
  "atty",
  "humantime",
- "log 0.4.17",
+ "log",
  "regex",
  "termcolor",
 ]
@@ -309,7 +309,7 @@ dependencies = [
  "anyhow",
  "builder",
  "format",
- "log 0.4.17",
+ "log",
  "nix",
  "oci",
  "reader",
@@ -371,16 +371,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
-name = "fuse"
-version = "0.3.1"
+name = "fuser"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e57070510966bfef93662a81cb8aa2b1c7db0964354fa9921434f04b9e8660"
+checksum = "104ed58f182bc2975062cd3fab229e82b5762de420e26cf5645f661402694599"
 dependencies = [
  "libc",
- "log 0.3.9",
+ "log",
+ "memchr",
+ "page_size",
  "pkg-config",
- "thread-scoped",
- "time 0.1.44",
+ "smallvec",
+ "users",
+ "zerocopy",
 ]
 
 [[package]]
@@ -489,15 +492,6 @@ checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "log"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-dependencies = [
- "log 0.4.17",
-]
-
-[[package]]
-name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
@@ -602,6 +596,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
 
 [[package]]
+name = "page_size"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebde548fbbf1ea81a99b128872779c437752fb99f217c45245e1a61dcd9edcd"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,7 +697,7 @@ dependencies = [
  "env_logger",
  "extractor",
  "format",
- "log 0.4.17",
+ "log",
  "nix",
  "oci",
  "os_pipe",
@@ -795,13 +799,12 @@ dependencies = [
  "builder",
  "compression",
  "format",
- "fuse",
+ "fuser",
  "hex",
  "nix",
  "oci",
  "sha2",
  "tempfile",
- "time 0.1.44",
  "xattr",
 ]
 
@@ -919,6 +922,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
 name = "strsim"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,8 +959,8 @@ dependencies = [
  "error-chain",
  "hostname",
  "libc",
- "log 0.4.17",
- "time 0.3.17",
+ "log",
+ "time",
 ]
 
 [[package]]
@@ -1025,29 +1034,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread-scoped"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbb6aa301e5d3b0b5ef639c9a9c7e2f1c944f177b460c04dc24c69b1fa2bd99"
-
-[[package]]
 name = "threadpool"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
-]
-
-[[package]]
-name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi",
- "winapi",
 ]
 
 [[package]]
@@ -1096,6 +1088,16 @@ name = "unicode-ident"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+
+[[package]]
+name = "users"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
+dependencies = [
+ "libc",
+ "log",
+]
 
 [[package]]
 name = "version_check"
@@ -1167,6 +1169,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332f188cc1bcf1fe1064b8c58d150f497e697f49774aa846f2dc949d9a25f236"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6505e6815af7de1746a08f69c69606bb45695a17149517680f3b2149713b19a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/exe/src/main.rs
+++ b/exe/src/main.rs
@@ -107,7 +107,7 @@ fn main() -> anyhow::Result<()> {
                 .unwrap();
 
                 let fuse_thread_finished = send;
-                let _guard = spawn_mount(&image, &m.tag, &mountpoint, Some(fuse_thread_finished))?;
+                let _guard = spawn_mount(image, &m.tag, &mountpoint, Some(fuse_thread_finished))?;
                 // This blocks until either ctrl-c is pressed or the filesystem is unmounted
                 let () = recv.recv().unwrap();
             } else {
@@ -155,7 +155,7 @@ fn main() -> anyhow::Result<()> {
 
                         let (fuse_thread_finished, recv) = std::sync::mpsc::channel();
                         let guard =
-                            spawn_mount(&image, &m.tag, &mountpoint, Some(fuse_thread_finished));
+                            spawn_mount(image, &m.tag, &mountpoint, Some(fuse_thread_finished));
                         match guard {
                             Ok(_res) => {
                                 // This blocks until the filesystem is unmounted

--- a/extractor/src/lib.rs
+++ b/extractor/src/lib.rs
@@ -71,7 +71,7 @@ pub fn extract_rootfs(oci_dir: &str, tag: &str, extract_dir: &str) -> anyhow::Re
     let image = Image::new(oci_dir)?;
     let dir = Path::new(extract_dir);
     fs::create_dir_all(dir)?;
-    let mut pfs = PuzzleFS::open(&image, tag)?;
+    let mut pfs = PuzzleFS::open(image, tag)?;
     let mut walker = WalkPuzzleFS::walk(&mut pfs)?;
     let mut host_to_pfs = HashMap::<format::Ino, PathBuf>::new();
 

--- a/reader/Cargo.toml
+++ b/reader/Cargo.toml
@@ -10,8 +10,7 @@ edition = "2018"
 compression = { path = "../compression" }
 format = { path = "../format" }
 oci = { path = "../oci" }
-fuse = "*"
-time = "0.1.44"
+fuser = "0.11.1"
 nix = "*"
 
 [dev-dependencies]

--- a/reader/src/lib.rs
+++ b/reader/src/lib.rs
@@ -1,4 +1,4 @@
-extern crate fuse as fuse_ffi;
+extern crate fuser as fuse_ffi;
 
 use std::path::Path;
 
@@ -14,20 +14,20 @@ pub use crate::fuse::Fuse;
 mod walk;
 pub use walk::WalkPuzzleFS;
 
-pub fn mount(image: &Image, tag: &str, mountpoint: &Path) -> Result<()> {
+pub fn mount(image: Image, tag: &str, mountpoint: &Path) -> Result<()> {
     let pfs = PuzzleFS::open(image, tag)?;
     let fuse = Fuse::new(pfs, None);
-    fuse_ffi::mount(fuse, &mountpoint, &[])?;
+    fuse_ffi::mount2(fuse, mountpoint, &[])?;
     Ok(())
 }
 
-pub fn spawn_mount<'a>(
-    image: &'a Image,
+pub fn spawn_mount(
+    image: Image,
     tag: &str,
     mountpoint: &Path,
     sender: Option<std::sync::mpsc::Sender<()>>,
-) -> Result<fuse_ffi::BackgroundSession<'a>> {
+) -> Result<fuse_ffi::BackgroundSession> {
     let pfs = PuzzleFS::open(image, tag)?;
     let fuse = Fuse::new(pfs, sender);
-    unsafe { Ok(fuse_ffi::spawn_mount(fuse, &mountpoint, &[])?) }
+    Ok(fuse_ffi::spawn_mount2(fuse, mountpoint, &[])?)
 }


### PR DESCRIPTION
Features:
* libfuse3 or libfuse are automatically detected
* supports compilation without libfuse by specifying "default-features = false" in Cargo.toml, see https://github.com/cberner/fuser/commit/4dc1dcc8053dd190326aadf4ae5e7062ee9ef178

This requires changes in structure definitions, mainly because (the unsafe) thread-scoped was removed from fuser in https://github.com/cberner/fuser/commit/f20051e6bdbe809c13e0d41ef5e2592df84b5b53

Because thread-scope was removed, the spawn_mount function signature was changed; fuse's spawn_mount function differs in signature from fuser's spawn_mount2 in the FS trait:
fuse: FS: Filesystem + Send + 'a
fuser: FS: Filesystem + Send + 'static + 'a

The 'static trait bound means that the type does not contain any non-static references. Any owned data always passes a 'static lifetime bound, but a reference to that owned data generally does not. https://doc.rust-lang.org/rust-by-example/scope/lifetime/static_lifetime.html

In short, scoped threads allowed us to borrow non-'static data, so it was ok for struct PuzzleFs to store a reference to an Image. Since we're not using thread-scope anymore, PuzzleFs needs to own its fields instead of storing references, so the structure can be moved into another thread. We use an Arc<Image> which is a thread-safe reference-counting pointer.

Signed-off-by: Ariel Miculas <amiculas@cisco.com>