### PR TITLE
Allow passing the O_NOFOLLOW flag to the open syscall

### DIFF
--- a/reader/src/fuse.rs
+++ b/reader/src/fuse.rs
@@ -72,8 +72,11 @@ impl Fuse {
     }
 
     fn _open(&self, flags_i: i32, reply: ReplyOpen) {
-        let allowed_flags =
-            OFlag::O_RDONLY | OFlag::O_PATH | OFlag::O_NONBLOCK | OFlag::O_DIRECTORY;
+        let allowed_flags = OFlag::O_RDONLY
+            | OFlag::O_PATH
+            | OFlag::O_NONBLOCK
+            | OFlag::O_DIRECTORY
+            | OFlag::O_NOFOLLOW;
         let flags = OFlag::from_bits_truncate(flags_i);
         if !allowed_flags.contains(flags) {
             reply.error(Errno::EROFS as i32)


### PR DESCRIPTION
O_NOFOLLOW's behavior is handled by fuse.

Given the mounted puzzlefs filesystem at /tmp/puzzle $ ls -la /tmp/puzzle
total 0
drwxr-xr-x 0 amiculas amiculas    0 Jan  1  1970 dir-1
drwxr-xr-x 0 amiculas amiculas    0 Jan  1  1970 dir-2
drwxr-xr-x 0 amiculas amiculas    0 Jan  1  1970 dir-3
drwxr-xr-x 0 amiculas amiculas    0 Jan  1  1970 dir-4
-rw-r--r-- 0 amiculas amiculas 5454 Jan  1  1970 file1
-rw-r--r-- 0 amiculas amiculas   25 Jan  1  1970 file2
lrwxrwxrwx 0 amiculas amiculas    0 Jan  1  1970 file-sym -> file1

The result of openat with O_NOFOLLOW is:
openat(AT_FDCWD, "/tmp/puzzle/file1", O_RDONLY|O_NOFOLLOW) = 4 openat(AT_FDCWD, "/tmp/puzzle/file-sym", O_RDONLY|O_NOFOLLOW) = -1 ELOOP (Too many levels of symbolic links)

Signed-off-by: Ariel Miculas <amiculas@cisco.com>