### PR TITLE
Add --base-layer option to puzzlefs build

### DIFF
--- a/builder/src/fastcdc_fs.rs
+++ b/builder/src/fastcdc_fs.rs
@@ -157,8 +157,8 @@ mod tests {
         wrapper.get_pending_chunks(&mut chunks);
 
         for (i, (fcdc, ours)) in fcdc_results.iter().zip(&chunks).enumerate() {
-            assert_eq!(fcdc.offset, ours.offset, "offset {}", i);
-            assert_eq!(fcdc.length, ours.length, "length {}", i);
+            assert_eq!(fcdc.offset, ours.offset, "offset {i}");
+            assert_eq!(fcdc.length, ours.length, "length {i}");
         }
         assert_eq!(fcdc_results.len(), chunks.len(), "number of chunks");
     }
@@ -191,8 +191,8 @@ mod tests {
         wrapper.get_pending_chunks(&mut chunks);
 
         for (i, (fcdc, ours)) in fcdc_results.iter().zip(&chunks).enumerate() {
-            assert_eq!(fcdc.offset, ours.offset, "offset {}", i);
-            assert_eq!(fcdc.length, ours.length, "length {}", i);
+            assert_eq!(fcdc.offset, ours.offset, "offset {i}");
+            assert_eq!(fcdc.length, ours.length, "length {i}");
         }
         assert_eq!(fcdc_results.len(), chunks.len(), "number of chunks");
     }

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -488,7 +488,7 @@ pub fn build_initial_rootfs(rootfs: &Path, oci: &Image) -> Result<Descriptor> {
 
 // add_rootfs_delta adds whatever the delta between the current rootfs and the puzzlefs
 // representation from the tag is.
-pub fn add_rootfs_delta(rootfs: &Path, oci: Image, tag: &str) -> Result<()> {
+pub fn add_rootfs_delta(rootfs: &Path, oci: Image, tag: &str) -> Result<Descriptor> {
     let pfs = PuzzleFS::open(oci, tag)?;
     let oci = Arc::clone(&pfs.oci);
     let desc = build_delta(rootfs, &oci, Some(pfs))?;
@@ -502,9 +502,7 @@ pub fn add_rootfs_delta(rootfs: &Path, oci: Image, tag: &str) -> Result<()> {
     rootfs.metadatas.insert(0, br);
     let mut rootfs_buf = Vec::new();
     serde_cbor::to_writer(&mut rootfs_buf, &rootfs)?;
-    let rootfs_desc =
-        oci.put_blob::<_, compression::Noop, media_types::Rootfs>(rootfs_buf.as_slice())?;
-    oci.add_tag(tag.to_string(), rootfs_desc)
+    oci.put_blob::<_, compression::Noop, media_types::Rootfs>(rootfs_buf.as_slice())
 }
 
 // TODO: figure out how to guard this with #[cfg(test)]
@@ -602,11 +600,15 @@ pub mod tests {
         )
         .unwrap();
 
-        add_rootfs_delta(&delta_dir, image.clone(), &tag).unwrap();
-        let delta = image.open_rootfs_blob::<compression::Noop>(&tag).unwrap();
+        let desc = add_rootfs_delta(&delta_dir, image.clone(), &tag).unwrap();
+        let new_tag = "test2".to_string();
+        image.add_tag(new_tag.to_string(), desc).unwrap();
+        let delta = image
+            .open_rootfs_blob::<compression::Noop>(&new_tag)
+            .unwrap();
         assert_eq!(delta.metadatas.len(), 2);
 
-        let mut pfs = PuzzleFS::open(image, &tag).unwrap();
+        let mut pfs = PuzzleFS::open(image, &new_tag).unwrap();
         assert_eq!(pfs.max_inode().unwrap(), 3);
         let mut walker = WalkPuzzleFS::walk(&mut pfs).unwrap();
 

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -792,7 +792,7 @@ pub mod tests {
             sha_suite.push(ents);
 
             if i != 0 && !do_vecs_match(&sha_suite[i - 1], &sha_suite[i]) {
-                println!("not matching at iteration: {}", i);
+                println!("not matching at iteration: {i}");
                 return false;
             }
         }
@@ -815,7 +815,7 @@ pub mod tests {
             sha_suite.push(ents);
 
             if i != 0 && !do_vecs_match(&sha_suite[i - 1], &sha_suite[i]) {
-                println!("not matching at iteration: {}", i);
+                println!("not matching at iteration: {i}");
                 return false;
             }
         }

--- a/compression/src/zstd.rs
+++ b/compression/src/zstd.rs
@@ -131,7 +131,7 @@ impl Compression for Zstd {
     }
 
     fn append_extension(media_type: &str) -> String {
-        format!("{}+zstd", media_type)
+        format!("{media_type}+zstd")
     }
 }
 

--- a/exe/src/main.rs
+++ b/exe/src/main.rs
@@ -70,7 +70,7 @@ fn init_syslog() -> std::io::Result<()> {
 
     let logger = match syslog::unix(formatter) {
         Err(e) => {
-            println!("impossible to connect to syslog: {:?}", e);
+            println!("impossible to connect to syslog: {e:?}");
             return Err(std::io::Error::last_os_error());
         }
         Ok(logger) => logger,
@@ -176,7 +176,7 @@ fn main() -> anyhow::Result<()> {
                         close(std::io::stderr().as_raw_fd()).expect("cannot close stderr");
                         thread_handle.join().expect("Cannot join thread");
                     }
-                    Err(e) => eprintln!("Error, {}", e),
+                    Err(e) => eprintln!("Error, {e}"),
                 }
             }
 

--- a/format/src/types.rs
+++ b/format/src/types.rs
@@ -136,7 +136,7 @@ impl<'de> Deserialize<'de> for BlobRef {
             type Value = BlobRef;
 
             fn expecting(&self, formatter: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                formatter.write_fmt(format_args!("expected {} bytes for BlobRef", BLOB_REF_SIZE))
+                formatter.write_fmt(format_args!("expected {BLOB_REF_SIZE} bytes for BlobRef"))
             }
 
             fn visit_bytes<E>(self, v: &[u8]) -> std::result::Result<BlobRef, E>
@@ -280,7 +280,7 @@ impl<'de> Deserialize<'de> for Inode {
             type Value = Inode;
 
             fn expecting(&self, formatter: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                formatter.write_fmt(format_args!("expected {} bytes for Inode", INODE_MODE_SIZE))
+                formatter.write_fmt(format_args!("expected {INODE_MODE_SIZE} bytes for Inode"))
             }
 
             fn visit_bytes<E>(self, v: &[u8]) -> std::result::Result<Inode, E>
@@ -358,7 +358,7 @@ impl Inode {
         if !md.is_dir() {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
-                format!("{} is a dir", ino),
+                format!("{ino} is a dir"),
             ));
         }
 
@@ -375,7 +375,7 @@ impl Inode {
         if !md.is_file() {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
-                format!("{} is a file", ino),
+                format!("{ino} is a file"),
             ));
         }
 
@@ -394,7 +394,7 @@ impl Inode {
         } else if file_type.is_dir() {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
-                format!("{} is a dir", ino),
+                format!("{ino} is a dir"),
             ));
         } else if file_type.is_block_device() {
             let major = stat::major(md.rdev());
@@ -403,7 +403,7 @@ impl Inode {
         } else if file_type.is_file() {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
-                format!("{} is a file", ino),
+                format!("{ino} is a file"),
             ));
         } else if file_type.is_symlink() {
             InodeMode::Lnk
@@ -513,7 +513,7 @@ mod tests {
         for test in testcases {
             let wire = test.to_wire().unwrap();
             let after = serde_cbor::from_reader(&*wire).unwrap();
-            assert_eq!(wire.len(), INODE_WIRE_SIZE, "{:?}", test);
+            assert_eq!(wire.len(), INODE_WIRE_SIZE, "{test:?}");
             assert_eq!(test, after);
         }
     }
@@ -628,7 +628,7 @@ impl MetadataBlob {
     }
 
     pub fn find_inode(&mut self, ino: Ino) -> Result<Option<Inode>> {
-        self.f.seek(io::SeekFrom::Start(0))?;
+        self.f.rewind()?;
         let inode_count = cbor_get_array_size(&mut self.f)?;
         let mut left = 0;
         let mut right = inode_count;
@@ -660,7 +660,7 @@ impl MetadataBlob {
     }
 
     pub fn read_inodes(&mut self) -> Result<Vec<Inode>> {
-        self.f.seek(io::SeekFrom::Start(0))?;
+        self.f.rewind()?;
         read_one(&mut self.f)
     }
 

--- a/oci/src/descriptor.rs
+++ b/oci/src/descriptor.rs
@@ -81,7 +81,7 @@ impl<'de> Deserialize<'de> for Digest {
             {
                 let parts: Vec<&str> = s.split(':').collect();
                 if parts.len() != 2 {
-                    return Err(SerdeError::custom(format!("bad digest {}", s)));
+                    return Err(SerdeError::custom(format!("bad digest {s}")));
                 }
 
                 match parts[0] {
@@ -91,7 +91,7 @@ impl<'de> Deserialize<'de> for Digest {
 
                         let len = buf.len();
                         let digest: [u8; SHA256_BLOCK_SIZE] = buf.try_into().map_err(|_| {
-                            SerdeError::custom(format!("invalid sha256 block length {}", len))
+                            SerdeError::custom(format!("invalid sha256 block length {len}"))
                         })?;
                         Ok(Digest(digest))
                     }

--- a/oci/src/lib.rs
+++ b/oci/src/lib.rs
@@ -114,7 +114,7 @@ impl Image {
         let index = self.get_index()?;
         let desc = index
             .find_tag(tag)
-            .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, format!("no tag {}", tag)))?;
+            .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, format!("no tag {tag}")))?;
         let rootfs = Rootfs::open(self.open_compressed_blob::<C>(&desc.digest)?)?;
         Ok(rootfs)
     }


### PR DESCRIPTION
This option exposes add_rootfs_delta which allows us to determine the delta between the rootfs and an existing puzzlefs layer and then to build a new layer consisting of only the delta. This is in theory, the current implementation needs some improvements.

Signed-off-by: Ariel Miculas <amiculas@cisco.com>