### PR TITLE
Pass mount options to puzzlefs with the -o flag

### DIFF
--- a/exe/src/main.rs
+++ b/exe/src/main.rs
@@ -12,8 +12,6 @@ use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 use syslog::{BasicLogger, Facility, Formatter3164};
 
-const DEFAULT_MOUNT_OPTIONS: [&str; 1] = ["allow_other"];
-
 #[derive(Parser)]
 #[command(author, version, about)]
 struct Opts {
@@ -46,6 +44,8 @@ struct Mount {
     foreground: bool,
     #[arg(short, long, value_name = "init-pipe")]
     init_pipe: Option<String>,
+    #[arg(short, value_delimiter = ',')]
+    options: Option<Vec<String>>,
 }
 
 #[derive(Args)]
@@ -138,7 +138,7 @@ fn main() -> anyhow::Result<()> {
                     image,
                     &m.tag,
                     &mountpoint,
-                    &DEFAULT_MOUNT_OPTIONS,
+                    &m.options.unwrap_or_default(),
                     m.init_pipe
                         .map(|x| PipeDescriptor::NamedPipe(PathBuf::from(x))),
                     Some(fuse_thread_finished),
@@ -161,7 +161,7 @@ fn main() -> anyhow::Result<()> {
                             image,
                             &m.tag,
                             &mountpoint,
-                            &DEFAULT_MOUNT_OPTIONS,
+                            &m.options.unwrap_or_default()[..],
                             Some(PipeDescriptor::UnnamedPipe(init_notify)),
                         )?;
                     }

--- a/reader/src/fuse.rs
+++ b/reader/src/fuse.rs
@@ -672,8 +672,15 @@ mod tests {
         let rootfs_desc = build_test_fs(Path::new("../builder/test/test-1"), &image).unwrap();
         image.add_tag("test".to_string(), rootfs_desc).unwrap();
         let mountpoint = tempdir().unwrap();
-        let _bg = crate::spawn_mount(image, "test", Path::new(mountpoint.path()), &[], None, None)
-            .unwrap();
+        let _bg = crate::spawn_mount::<&str>(
+            image,
+            "test",
+            Path::new(mountpoint.path()),
+            &[],
+            None,
+            None,
+        )
+        .unwrap();
         let ents = fs::read_dir(mountpoint.path())
             .unwrap()
             .collect::<io::Result<Vec<fs::DirEntry>>>()

--- a/reader/src/lib.rs
+++ b/reader/src/lib.rs
@@ -41,11 +41,11 @@ fn mount_option_from_str(s: &str) -> fuse_ffi::MountOption {
     }
 }
 
-pub fn mount(
+pub fn mount<T: AsRef<str>>(
     image: Image,
     tag: &str,
     mountpoint: &Path,
-    options: &[&str],
+    options: &[T],
     init_notify: Option<PipeDescriptor>,
 ) -> Result<()> {
     let pfs = PuzzleFS::open(image, tag)?;
@@ -55,17 +55,17 @@ pub fn mount(
         mountpoint,
         &options
             .iter()
-            .map(|option| mount_option_from_str(option))
+            .map(|option| mount_option_from_str(option.as_ref()))
             .collect::<Vec<_>>(),
     )?;
     Ok(())
 }
 
-pub fn spawn_mount(
+pub fn spawn_mount<T: AsRef<str>>(
     image: Image,
     tag: &str,
     mountpoint: &Path,
-    options: &[&str],
+    options: &[T],
     init_notify: Option<PipeDescriptor>,
     sender: Option<std::sync::mpsc::Sender<()>>,
 ) -> Result<fuse_ffi::BackgroundSession> {
@@ -76,7 +76,7 @@ pub fn spawn_mount(
         mountpoint,
         &options
             .iter()
-            .map(|option| mount_option_from_str(option))
+            .map(|option| mount_option_from_str(option.as_ref()))
             .collect::<Vec<_>>(),
     )?)
 }


### PR DESCRIPTION
Possible options:
auto_unmount
allow_other
allow_root
default_permissions
dev
nodev
suid
nosuid
ro
rw
exec
noexec
atime
noatime
dirsync
sync
async
fsname=
subtype=

It supports comma separated values and multiple -o flags.

Example:
puzzlefs mount -o ro,allow_other ...
puzzlefs mount -o ro -o allow_other ...

Fixes #62

Signed-off-by: Ariel Miculas <amiculas@cisco.com>