### PR TITLE
Let cargo handle build dependencies and add the release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
 SRC=$(shell find . -name \*.rs | grep -v "^./target")
 
-target/debug/puzzlefs: $(SRC)
+.PHONY: debug
+debug:
 	cargo build
+
+.PHONY: release
+release:
+	cargo build --release
 
 .PHONY: check
 check:


### PR DESCRIPTION
The rust source files are not the only ones that need to trigger rebuilds (e.g. Cargo.toml changes should also trigger a rebuild). It's easier to just let cargo manage the dependencies and run cargo build at every make.
I've also added a release target for convenience.