### PR TITLE
Replace docker_extract with skopeo copy and umoci unpack

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,5 @@ jobs:
                 components: clippy, rustfmt
             - name: install dependencies
               run: |
-                sudo apt-get install libfuse-dev libzstd-dev libxxhash-dev
-                # docker_extract wants this to be in the local daemon
-                docker pull ubuntu:latest
+                sudo apt-get install libfuse-dev libzstd-dev libxxhash-dev skopeo umoci
             - run: make lint check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,7 @@ dependencies = [
  "clap_derive",
  "clap_lex",
  "once_cell",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
 ]
 
@@ -182,66 +182,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.9.3",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
-dependencies = [
- "darling",
- "derive_builder_core",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,18 +210,6 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
-name = "docker_extract"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08b5f72bb14debd5333dd9eae8b0ffc21351af3e04c0c14a153e4e460262aa1b"
-dependencies = [
- "derive_builder",
- "serde_json",
- "tar",
- "tempdir",
-]
 
 [[package]]
 name = "env_logger"
@@ -337,24 +265,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "filetime"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "winapi",
-]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "format"
 version = "0.1.0"
 dependencies = [
@@ -391,12 +301,6 @@ dependencies = [
  "hex",
  "sha2",
 ]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "fuser"
@@ -483,12 +387,6 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
@@ -813,7 +711,6 @@ dependencies = [
  "ctrlc",
  "daemonize",
  "dir-diff",
- "docker_extract",
  "env_logger",
  "extractor",
  "format",
@@ -840,26 +737,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.1",
+ "rand_core",
  "rand_hc",
 ]
 
@@ -870,23 +754,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.1",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -903,16 +772,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core 0.6.1",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -1054,12 +914,6 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "strsim"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -1089,31 +943,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tar"
-version = "0.4.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0bcfbd6a598361fda270d82469fff3d65089dc33e175c9a131f7b4cd395f228"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
-
-[[package]]
 name = "tee"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c12559dba7383625faaff75be24becf35bfc885044375bcab931111799a3da"
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
-]
 
 [[package]]
 name = "tempfile"
@@ -1123,7 +956,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if",
  "libc",
- "rand 0.8.3",
+ "rand",
  "redox_syscall",
  "remove_dir_all",
  "winapi",

--- a/exe/Cargo.toml
+++ b/exe/Cargo.toml
@@ -23,7 +23,6 @@ fsverity_helpers = { path = "../fsverity_helpers" }
 hex = "*"
 
 [dev-dependencies]
-docker_extract = "*"
 assert_cmd = "*"
 dir-diff = "*"
 tempfile = "*"

--- a/exe/tests/extract.rs
+++ b/exe/tests/extract.rs
@@ -12,13 +12,13 @@ use helpers::{get_image, puzzlefs};
 fn build_and_extract_is_noop() -> anyhow::Result<()> {
     let dir = tempdir().unwrap();
     let ubuntu = dir.path().join("ubuntu");
-    get_image(&ubuntu).unwrap();
+    let ubuntu_rootfs = get_image(ubuntu)?;
 
     // TODO: figure out a better way to do all this osstr stuff...
     let oci = dir.path().join("oci");
     puzzlefs([
         OsStr::new("build"),
-        ubuntu.as_ref(),
+        ubuntu_rootfs.as_ref(),
         oci.as_ref(),
         OsStr::new("test"),
     ])?;
@@ -30,6 +30,6 @@ fn build_and_extract_is_noop() -> anyhow::Result<()> {
         OsStr::new("test"),
         extracted.as_os_str(),
     ])?;
-    assert!(!dir_diff::is_different(ubuntu, extracted).unwrap());
+    assert!(!dir_diff::is_different(ubuntu_rootfs, extracted).unwrap());
     Ok(())
 }

--- a/exe/tests/helpers/mod.rs
+++ b/exe/tests/helpers/mod.rs
@@ -1,19 +1,87 @@
 use std::ffi::OsStr;
-use std::io;
+use std::fs;
 use std::path::Path;
+use std::path::PathBuf;
 use std::process::Command;
 use std::str;
 
 use anyhow::bail;
 use assert_cmd::cargo::CommandCargoExt;
+use std::env;
 
-pub fn get_image<P: AsRef<Path>>(to_dir: P) -> io::Result<()> {
+pub fn get_image<P: AsRef<Path>>(to_dir: P) -> anyhow::Result<PathBuf> {
     let image = "ubuntu";
     let tag = "latest";
     if to_dir.as_ref().exists() {
-        return Ok(());
+        let rootfs = to_dir.as_ref().join("rootfs");
+        if rootfs.exists() {
+            return Ok(rootfs);
+        } else {
+            bail!(
+                "{:?} exists but does not have a rootfs directory in it",
+                to_dir.as_ref().display()
+            );
+        }
     }
-    docker_extract::extract_image(image, tag, to_dir.as_ref())
+
+    let mut xdg_data_home_default = env::var("HOME").unwrap();
+    xdg_data_home_default.push_str("/.local/share");
+
+    let mut xdg_data_home = env::var("XDG_DATA_HOME").unwrap_or(xdg_data_home_default.clone());
+    if xdg_data_home.is_empty() {
+        xdg_data_home = xdg_data_home_default;
+    }
+
+    let puzzlefs_data_path = format!("{xdg_data_home}/puzzlefs");
+    fs::create_dir_all(&puzzlefs_data_path)?;
+
+    // skopeo copy docker://ubuntu:latest oci:$HOME/.local/share/puzzlefs/ubuntu:latest
+    let output = Command::new("skopeo")
+        .args([
+            "copy",
+            &format!("docker://{image}:{tag}"),
+            &format!("oci:{puzzlefs_data_path}/{image}:{tag}"),
+        ])
+        .output()?;
+    if !output.status.success() {
+        bail!(
+            "skopeo exited with error:\n{}",
+            str::from_utf8(&output.stderr)?,
+        );
+    }
+
+    if !output.stdout.is_empty() {
+        println!(
+            "skopeo output\n{}",
+            str::from_utf8(&output.stdout).expect("Script output should not contain non-UTF8")
+        );
+    }
+
+    // umoci unpack --rootless --image ubuntu:latest /tmp/.tmpxyz/ubuntu
+    let output = Command::new("umoci")
+        .args([
+            OsStr::new("unpack"),
+            OsStr::new("--rootless"),
+            OsStr::new("--image"),
+            OsStr::new(&format!("{puzzlefs_data_path}/{image}:{tag}")),
+            to_dir.as_ref().as_os_str(),
+        ])
+        .output()?;
+    if !output.status.success() {
+        bail!(
+            "umoci exited with error:\n{}",
+            str::from_utf8(&output.stderr)?,
+        );
+    }
+
+    if !output.stdout.is_empty() {
+        println!(
+            "umoci output\n{}",
+            str::from_utf8(&output.stdout).expect("Script output should not contain non-UTF8")
+        );
+    }
+
+    Ok(to_dir.as_ref().join("rootfs"))
 }
 
 pub fn puzzlefs<I, S>(args: I) -> anyhow::Result<String>


### PR DESCRIPTION
ubuntu:latest is downloaded into $XDG_DATA_HOME/puzzlefs/ubuntu using skopeo copy.

If $XDG_DATA_HOME is missing or it's an empty string, then $HOME/.local/share is used.

Then umoci unpack is used to extract the image into a temporary directory.

Fixes #68