### PR TITLE
Replace OsString with Vec<u8> in the serialized metadata

### DIFF
--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -13,6 +13,7 @@ use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::io;
 use std::os::fd::AsRawFd;
+use std::os::unix::ffi::OsStringExt;
 use std::os::unix::fs::MetadataExt;
 use std::path::Path;
 use std::sync::Arc;
@@ -57,7 +58,10 @@ struct Dir {
 
 impl Dir {
     fn add_entry(&mut self, name: OsString, ino: Ino) {
-        self.dir_list.entries.push(DirEnt { name, ino });
+        self.dir_list.entries.push(DirEnt {
+            name: OsString::into_vec(name),
+            ino,
+        });
     }
 }
 
@@ -644,7 +648,7 @@ pub mod tests {
             let dir_list: DirList = blob.read_dir_list(offset).unwrap();
             assert_eq!(dir_list.entries.len(), 1);
             assert_eq!(dir_list.entries[0].ino, 2);
-            assert_eq!(dir_list.entries[0].name, "SekienAkashita.jpg");
+            assert_eq!(dir_list.entries[0].name, b"SekienAkashita.jpg");
         } else {
             panic!("bad inode mode: {:?}", inodes[0].mode);
         }

--- a/extractor/src/lib.rs
+++ b/extractor/src/lib.rs
@@ -7,7 +7,9 @@ use nix::unistd::{chown, mkfifo, symlinkat, Gid, Uid};
 use oci::Image;
 use reader::{InodeMode, PuzzleFS, WalkPuzzleFS};
 use std::collections::HashMap;
+use std::ffi::OsStr;
 use std::fs::Permissions;
+use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Component, Path, PathBuf};
 use std::{fs, io};
@@ -108,7 +110,7 @@ pub fn extract_rootfs(oci_dir: &str, tag: &str, extract_dir: &str) -> anyhow::Re
                     format::InodeMode::Lnk => {
                         let target = dir_entry.inode.symlink_target()?;
                         is_symlink = true;
-                        symlinkat(target.as_os_str(), None, &path)?;
+                        symlinkat(target, None, &path)?;
                     }
                     format::InodeMode::Sock => {
                         todo!();
@@ -124,7 +126,7 @@ pub fn extract_rootfs(oci_dir: &str, tag: &str, extract_dir: &str) -> anyhow::Re
         }
         if let Some(x) = dir_entry.inode.additional {
             for x in &x.xattrs {
-                xattr::set(&path, &x.key, &x.val)?;
+                xattr::set(&path, OsStr::from_bytes(&x.key), &x.val)?;
             }
         }
 

--- a/reader/src/walk.rs
+++ b/reader/src/walk.rs
@@ -140,7 +140,7 @@ mod tests {
 
         fn check_inode_xattrs(inode: Inode) {
             let additional = inode.additional.unwrap();
-            assert_eq!(additional.xattrs[0].key, "user.meshuggah");
+            assert_eq!(additional.xattrs[0].key, b"user.meshuggah");
             assert_eq!(additional.xattrs[0].val, b"rocks");
         }
 


### PR DESCRIPTION
There's no reason to use OsString in the serialized metadata since we don't need a platform-native representation. So just use Vec<u8>, which is what OsStr uses under the hood for Unix systems. This simplifies the metadata decoding in the kernel.

Fixes #85