### PR TITLE
Change OsString to Vec<u8> in InodeMode

### DIFF
--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -13,7 +13,7 @@ use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::io;
 use std::os::fd::AsRawFd;
-use std::os::unix::ffi::OsStringExt;
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::os::unix::fs::MetadataExt;
 use std::path::Path;
 use std::sync::Arc;
@@ -236,12 +236,11 @@ fn build_delta<C: for<'a> Compression<'a> + Any>(
             .get_mut(&this_metadata.ino())
             .ok_or_else(|| WireFormatError::from_errno(Errno::ENOENT))?;
         for (name, ino) in existing_dirents {
-            if !(new_dirents)
-                .iter()
-                .any(|new| new.path().file_name().unwrap_or_else(|| OsStr::new("")) == name)
-            {
+            if !(new_dirents).iter().any(|new| {
+                new.path().file_name().unwrap_or_else(|| OsStr::new("")) == OsStr::from_bytes(&name)
+            }) {
                 pfs_inodes.push(Inode::new_whiteout(ino));
-                this_dir.add_entry(name, ino);
+                this_dir.add_entry(OsString::from_vec(name), ino);
             }
         }
 

--- a/reader/src/fuse.rs
+++ b/reader/src/fuse.rs
@@ -69,7 +69,7 @@ impl Fuse {
 
     fn _lookup(&mut self, parent: u64, name: &OsStr) -> Result<FileAttr> {
         let dir = self.pfs.find_inode(parent)?;
-        let ino = dir.dir_lookup(name)?;
+        let ino = dir.dir_lookup(name.as_bytes())?;
         self._getattr(ino)
     }
 
@@ -136,7 +136,7 @@ impl Fuse {
             let kind = mode_to_fuse_type(&inode)?;
 
             // if the buffer is full, let's skip the extra lookups
-            if reply.add(ino, (index + 1) as i64, kind, name) {
+            if reply.add(ino, (index + 1) as i64, kind, OsStr::from_bytes(name)) {
                 break;
             }
         }

--- a/reader/src/walk.rs
+++ b/reader/src/walk.rs
@@ -3,6 +3,8 @@ use std::path::PathBuf;
 
 use format::Result;
 use oci::Image;
+use std::ffi::OsStr;
+use std::os::unix::ffi::OsStrExt;
 use std::sync::Arc;
 
 use super::puzzlefs::{FileReader, Inode, InodeMode, PuzzleFS};
@@ -33,7 +35,7 @@ impl<'a> WalkPuzzleFS<'a> {
         if let InodeMode::Dir { ref entries } = dir.inode.mode {
             for (name, ino) in entries {
                 let inode = self.pfs.find_inode(*ino)?;
-                let path = dir.path.join(name);
+                let path = dir.path.join(OsStr::from_bytes(name));
                 self.q.push_back(DirEntry {
                     oci: Arc::clone(&self.pfs.oci),
                     path,


### PR DESCRIPTION
We need InodeMode in the puzzlefs kernel driver where we don't have OsString.