### PR TITLE
Fix buffer overread in file_read

### DIFF
--- a/reader/src/puzzlefs.rs
+++ b/reader/src/puzzlefs.rs
@@ -124,17 +124,18 @@ pub(crate) fn file_read(
             continue;
         }
 
-        // ok, need to read this chunk; how much?
-        let left_in_buf = data.len() - buf_offset;
-        let to_read = min(left_in_buf, chunk.len as usize);
-
-        let start = buf_offset;
-        let finish = start + to_read;
         let addl_offset = if offset > file_offset {
             offset - file_offset
         } else {
             0
         };
+
+        // ok, need to read this chunk; how much?
+        let left_in_buf = data.len() - buf_offset;
+        let to_read = min(left_in_buf, chunk.len as usize - addl_offset);
+
+        let start = buf_offset;
+        let finish = start + to_read;
         file_offset += addl_offset;
 
         // how many did we actually read?


### PR DESCRIPTION
Ensure we take the offset into account when reading from a file chunk, otherwise we might end up leaking another file's data, since the last chunk in the list of chunks can contain data from other files. This issue was observed while developing the kernel driver. The userspace implementation might not encounter it due to the way in which fuse handles the read operations.