### PR TITLE
[RFC] Add omit-verity flag for the build command

### DIFF
--- a/format/src/types.rs
+++ b/format/src/types.rs
@@ -72,7 +72,7 @@ fn read_one_from_slice<'a, T: Deserialize<'a>>(bytes: &'a [u8]) -> Result<T> {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Rootfs {
     pub metadatas: Vec<BlobRef>,
-    pub fs_verity_data: VerityData,
+    pub fs_verity_data: Option<VerityData>,
     pub manifest_version: u64,
 }
 

--- a/reader/src/puzzlefs.rs
+++ b/reader/src/puzzlefs.rs
@@ -163,7 +163,14 @@ impl PuzzleFS {
     pub fn open(oci: Image, tag: &str, manifest_verity: Option<&[u8]>) -> format::Result<PuzzleFS> {
         let rootfs = oci.open_rootfs_blob::<compression::Noop>(tag, manifest_verity)?;
         let verity_data = if manifest_verity.is_some() {
-            Some(rootfs.fs_verity_data)
+            if rootfs.fs_verity_data.is_some() {
+                rootfs.fs_verity_data
+            } else {
+                return Err(WireFormatError::InvalidFsVerityData(
+                    "missing verity data".to_string(),
+                    Backtrace::capture(),
+                ));
+            }
         } else {
             None
         };


### PR DESCRIPTION
Current use case: build a puzzlefs filesystem without fs verity data so it can be loaded by the puzzlefs kernel module.
If there are other use cases then it might be worth merging it. Nonetheless, the fs verity data structure probably needs to change from a BTreeMap to a Vec, that way we can deserialize it in the kernel module.