### PR TITLE
Remove unused code

### DIFF
--- a/format/src/types.rs
+++ b/format/src/types.rs
@@ -184,11 +184,6 @@ impl<'de> Deserialize<'de> for BlobRef {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct Metadata {
-    pub inodes: Vec<Inode>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
 pub struct DirEnt {
     pub ino: Ino,
     pub name: Vec<u8>,


### PR DESCRIPTION
This wasn't detected by the linter because it's a public function and it also derives Serialize.